### PR TITLE
Added 'Top element style' setting for list templates

### DIFF
--- a/src/Messenger.Client/Messenger.Client.csproj
+++ b/src/Messenger.Client/Messenger.Client.csproj
@@ -19,6 +19,8 @@
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <Version>0.3.1</Version>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Messenger.Client/Objects/MessengerPayload.cs
+++ b/src/Messenger.Client/Objects/MessengerPayload.cs
@@ -13,6 +13,9 @@ namespace Messenger.Client.Objects
         [JsonProperty("template_type")]
         public String TemplateType { get; set; }
 
+        [JsonProperty("top_element_style")]
+        public String TopElementStyle { get; set; }
+
         public ICollection<MessengerButton> Buttons { get; set; }
 
         public ICollection<MessengerElement> Elements { get; set; }


### PR DESCRIPTION
Added missing setting for lists to allow the first item to not be shown as a banner, equivalent to "compact"/"large" settings for the "top_element_style" element on list template (docs: https://developers.facebook.com/docs/messenger-platform/send-api-reference/list-template)